### PR TITLE
Add env variable to modify vibration time

### DIFF
--- a/haptic/haptic.go
+++ b/haptic/haptic.go
@@ -25,12 +25,12 @@ import (
         "encoding/json"
 	"fmt"
 	"log"
-        "io/ioutil"
+	"io/ioutil"
 	"os"
-        "os/user"
-        "path"
-        "strconv"
-        "strings"
+	"os/user"
+	"path"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -64,8 +64,8 @@ var (
         cookie     string
         timer      *time.Timer
         pvalue     uint32
-		configFile string
-		vibrateScale uint32
+        configFile string
+        vibrateScale uint32
 )
 
 const (

--- a/haptic/haptic.go
+++ b/haptic/haptic.go
@@ -64,7 +64,8 @@ var (
         cookie     string
         timer      *time.Timer
         pvalue     uint32
-        configFile string
+		configFile string
+		vibrateScale uint32
 )
 
 const (
@@ -194,7 +195,7 @@ func handleHapticInterface(msg *dbus.Message) (reply *dbus.Message) {
 	case "Vibrate":
 		var duration uint32
 		msg.Args(&duration)
-		if err := Vibrate(duration); err != nil {
+		if err := Vibrate(duration + vibrateScale); err != nil {
 			reply = dbus.NewErrorMessage(msg, "com.canonical.usensord.Error", err.Error())
 		} else {
 			reply = dbus.NewMethodReturnMessage(msg)
@@ -281,9 +282,10 @@ func VibratePattern(duration []uint32, repeat uint32) (err error) {
 }
 
 // Init exposes the haptic device object path on the bus.
-func Init(log *log.Logger) (err error) {
+func Init(log *log.Logger, uint32 scale) (err error) {
 
 	logger = log
+	vibrateScale = scale
 	if conn, err = dbus.Connect(dbus.SessionBus); err != nil {
 		logger.Fatal("Connection error:", err)
 		return err

--- a/haptic/haptic.go
+++ b/haptic/haptic.go
@@ -282,7 +282,7 @@ func VibratePattern(duration []uint32, repeat uint32) (err error) {
 }
 
 // Init exposes the haptic device object path on the bus.
-func Init(log *log.Logger, uint32 scale) (err error) {
+func Init(log *log.Logger, scale uint32) (err error) {
 
 	logger = log
 	vibrateScale = scale

--- a/usensord.go
+++ b/usensord.go
@@ -90,7 +90,7 @@ func main() {
 	var (
 	err error
 	vibrateScale int
-)
+	)
 
 	vibrateScale, err = strconv.Atoi(os.Getenv("VIBRATE_SCALE"))
 	if err != nil {

--- a/usensord.go
+++ b/usensord.go
@@ -99,7 +99,7 @@ func main() {
 	} else {
 		logger.Println("Using custom vibrate scale of %d", uint32(vibrateScale))
 	}
-	err = haptic.Init(logger, vibrateScale)
+	err = haptic.Init(logger, uint32(vibrateScale))
 	if err != nil {
 		logger.Println("Error starting haptic service")
 	}

--- a/usensord.go
+++ b/usensord.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"strconv"
 )
 
 var logger *log.Logger
@@ -86,7 +87,14 @@ func init() {
 
 func main() {
 
-	err := haptic.Init(logger)
+	vibrateScale, err := strconv.Atoi(os.Getenv("VIBRATE_SCALE"))
+	if err != nil {
+		vibrateScale = 0
+		logger.Println("Using default vibrate scale of 0")
+	} else {
+		logger.Println("Using custom vibrate scale of %d", vibrateScale)
+	}
+	err := haptic.Init(logger, vibrateScale)
 	if err != nil {
 		logger.Println("Error starting haptic service")
 	}

--- a/usensord.go
+++ b/usensord.go
@@ -89,7 +89,7 @@ func main() {
 
 	var (
 	err error
-	vibrateScale uint32
+	vibrateScale int
 )
 
 	vibrateScale, err = strconv.Atoi(os.Getenv("VIBRATE_SCALE"))
@@ -97,7 +97,7 @@ func main() {
 		vibrateScale = 0
 		logger.Println("Using default vibrate scale of 0")
 	} else {
-		logger.Println("Using custom vibrate scale of %d", vibrateScale)
+		logger.Println("Using custom vibrate scale of %d", uint32(vibrateScale))
 	}
 	err = haptic.Init(logger, vibrateScale)
 	if err != nil {

--- a/usensord.go
+++ b/usensord.go
@@ -95,9 +95,9 @@ func main() {
 	vibrateScale, err = strconv.Atoi(os.Getenv("VIBRATE_SCALE"))
 	if err != nil {
 		vibrateScale = 0
-		logger.Println("Using default vibrate scale of 0")
+		logger.Println("Using default vibrate duration")
 	} else {
-		logger.Println("Using custom vibrate scale of %d", uint32(vibrateScale))
+		logger.Println("Extending vibrate duration by ", uint32(vibrateScale), "ms")
 	}
 	err = haptic.Init(logger, uint32(vibrateScale))
 	if err != nil {

--- a/usensord.go
+++ b/usensord.go
@@ -87,14 +87,19 @@ func init() {
 
 func main() {
 
-	vibrateScale, err := strconv.Atoi(os.Getenv("VIBRATE_SCALE"))
+	var (
+	err error
+	vibrateScale uint32
+)
+
+	vibrateScale, err = strconv.Atoi(os.Getenv("VIBRATE_SCALE"))
 	if err != nil {
 		vibrateScale = 0
 		logger.Println("Using default vibrate scale of 0")
 	} else {
 		logger.Println("Using custom vibrate scale of %d", vibrateScale)
 	}
-	err := haptic.Init(logger, vibrateScale)
+	err = haptic.Init(logger, vibrateScale)
 	if err != nil {
 		logger.Println("Error starting haptic service")
 	}


### PR DESCRIPTION
Some devices, like the Oneplus One, need a longer time to kickoff the vibration motor so that the user gets actually a good feedback. With this env variable introduced here usensord can extend the vibration time a bit.
